### PR TITLE
bpo-24925: _find_lineno now finds doctest __test__ string line numbers

### DIFF
--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1097,6 +1097,14 @@ class DocTestFinder:
         if inspect.iscode(obj):
             lineno = getattr(obj, 'co_firstlineno', None)-1
 
+        # Find the line number for triple quoted __test__ strings.
+        if isinstance(obj, str):
+            # find a line in the string that is unique in source lines
+            # and start counting from there
+            for offset, line in enumerate(obj.splitlines(True)):
+                if source_lines.count(line) == 1:
+                    return source_lines.index(line) - offset
+
         # Find the line number where the docstring starts.  Assume
         # that it's the first line that begins with a quote mark.
         # Note: this could be fooled by a multiline function


### PR DESCRIPTION
If the doctest code is in a __test__ string, _find_lineno now find the error, by looking for a line in the docstring that is unique in the source file.